### PR TITLE
Hide "Insert image" in preview mode and reword About

### DIFF
--- a/src/modules/about/About.tsx
+++ b/src/modules/about/About.tsx
@@ -12,11 +12,12 @@ const About = () => (
     </p>
     <p className={styles.body}>
       Along the way I've worn a lot of hats: architect, team lead, mentor, and occasionally the person who figures out
-      why the build is broken. It was never, ever my fault, not even once ((cough)).
+      why the build is broken. It was never, ever my fault, not even once. 😬 🤦🏻‍♂️
     </p>
     <p className={styles.body}>
-      For the last few years or so work felt less and less rewarding and I was burned out. Depressed. Anxious. So, I
-      retired early (a hot minute before Amazon likely would have laid me off).
+      For the last few years or so work felt less and less rewarding. I was burned out, depressed, and anxious. So... I
+      retired early, probably a hot minute before Amazon would have laid me off anyway (as most of my colleagues were
+      soon after).
     </p>
     <p className={styles.body}>
       Now that I have the time, I'm leaning into the things I enjoy — working on the house with my wonderful wife,

--- a/src/modules/blog/components/blog-post-form/BlogPostForm.tsx
+++ b/src/modules/blog/components/blog-post-form/BlogPostForm.tsx
@@ -207,14 +207,16 @@ const BlogPostForm = ({ initialValues, isEdit = false }: BlogPostFormProps) => {
                 Content <span className={styles.formatHint}>Markdown</span>
               </label>
               <div className={styles.contentTools}>
-                <Button
-                  label='Insert image'
-                  icon='pi pi-image'
-                  text
-                  size='small'
-                  type='button'
-                  onClick={() => setPickerVisible(true)}
-                />
+                {!showPreview && (
+                  <Button
+                    label='Insert image'
+                    icon='pi pi-image'
+                    text
+                    size='small'
+                    type='button'
+                    onClick={() => setPickerVisible(true)}
+                  />
+                )}
                 <Button
                   label={showPreview ? 'Write' : 'Preview'}
                   icon={showPreview ? 'pi pi-pencil' : 'pi pi-eye'}


### PR DESCRIPTION
## Summary

- Hide the "Insert image" button in the musings editor while preview mode is active. The picker copies a markdown snippet to paste into the textarea, and the textarea isn't there in preview — so the button had nothing to act on.
- Copy edits to the About page (build-breaking confession now has emoji; the retirement paragraph reads a bit more plainly).

## Test plan

- `npm run lint` and `npx tsc --noEmit` pass.
- Manual: on New Musing / Edit Musing, "Insert image" shows in write mode and opens the picker; switching to Preview leaves only the Write toggle; switching back restores it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8KvWHQhZbGY1PwFG7WoQh